### PR TITLE
Only output ANSI colors in the terminal

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,4 +25,4 @@ var deprecate = module.exports = function(methodName, message) {
 
 deprecate.stream = process.stderr;
 deprecate.silence = false;
-deprecate.color = '\x1b[31;1m';
+deprecate.color = deprecate.stream.isTTY && '\x1b[31;1m';


### PR DESCRIPTION
When redirecting STDERR output to a log file (and not the console), it's normal to disable the use of ANSI colors. This commit defaults to this behaviour. If you overwrite the `color` property you can still get the old behaviour.

I know this is a breaking change so feel free to suggest alternatives, but I feel this would be ok
