### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,48 +2,101 @@
 
 [![Build Status](https://secure.travis-ci.org/brianc/node-deprecate.png?branch=master)](http://travis-ci.org/brianc/node-deprecate)
 
-Mark a method as deprecated.  Write a message to a stream the first time the deprecated method is called.
+Mark a method as deprecated.  Write a message to a stream once for each location in an application the deprecated method is called.
 
 ## api
 
 `var deprecate = require('deprecate');`
 
-### deprecate([string message1 [, string message2 [,...]]])
+### deprecate()
+> function signature:
+```js
+deprecate([String message1 [, String message2 [,...]]], [Object options])
+```
 
 Call `deprecate` within a function you are deprecating.  It will spit out all the messages to the console the first time _and only the first time_ the method is called.
 
 ```js
-var deprecate = require('deprecate');
+1  │ var deprecate = require('deprecate');
+2  │
+3  │ var someDeprecatedFunction = function() {
+4  │   deprecate('someDeprecatedFunction() is deprecated');
+5  │ };
+6  │
+…  │ // …
+30 │
+31 │ someDeprecatedFunction();
+```
 
-var someDeprecatedFunction = function() {
-  deprecate('someDeprecatedFunction() is deprecated');
-};
+_program output:_
 
-someDeprecatedFunction();
-someDeprecatedFunction();
-someDeprecatedFunction();
-console.log('end');
+<img width="373" src="https://cloud.githubusercontent.com/assets/1958812/20812831/f2a1cde0-b7c7-11e6-93e6-1613e028e719.png">
 
-//program output:
+#### Options
 
-WARNING!!
-someDeprecatedFunction() is deprecated
+**`location`**: a string in the format `${filepath}:${line}:${column}` indicating where the deprecated function was called from.  _TODO: `false` disables outputting the location and will only log the message once._
 
+### deprecate.method()
+> function signature:
+```js
+deprecate.method(Object proto, String methodName, [String message1 [, String message2 [,...]]], [Object options])
+```
 
-end
+Deprecates a method on an object:
+
+```js
+deprecate.method(console, 'log', 'You should not log.');
+```
+
+### deprecate.fn()
+> function signature:
+```js
+deprecate.fn(Function func, [String message1 [, String message2 [,...]]], [Object options])
+```
+
+Deprecates a function and returns it:
+
+```js
+console.log = deprecate.fn(console.log, 'You should not log.');
 ```
 
 ### deprecate.color
 
-Set to `false` to not output a color.  Defaults to `'\x1b[31;1m'` which is red.
+Set to `false` to disable color output.  Set to `true` to force color output.  Defaults to the value of `deprecate.stream.isTTY`.
+
+
+### deprecate.colors
+
+Controls the colors used when logging. Default value:
+```js
+{
+  warning: '\x1b[31;1m', // red, bold
+  message: false, // use system color
+  location: '\u001b[90m' // gray
+}
+```
+
+_How the default looks on a light background:_
+
+<img width="344" src="https://cloud.githubusercontent.com/assets/1958812/20812832/f2a1edb6-b7c7-11e6-81f5-73319ae5f968.png">
+
+_And on a dark background:_
+
+<img width="373" src="https://cloud.githubusercontent.com/assets/1958812/20812831/f2a1cde0-b7c7-11e6-93e6-1613e028e719.png">
 
 ### deprecate.silence
 
-Do nothing at all when the deprecate method is called.
+When `true`, do nothing when the deprecate method is called.
 
 ### deprecate.stream
 
-The to which output is written.  Defaults to `process.stderr`
+The to which output is written.  Defaults to `process.stderr`.
+
+### deprecate.log(message)
+
+The function used to log, by default this function writes to `deprecate.stream` and falls back to `console.warn`.
+
+You can replace this with your own logging method.
 
 ## license
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ Mark a method as deprecated.  Write a message to a stream once for each location
 `var deprecate = require('deprecate');`
 
 ### deprecate()
-> function signature:
-```js
-deprecate([String message1 [, String message2 [,...]]], [Object options])
-```
+<sup>
+`deprecate([String message1 [, String message2 [,...]]], [Object options])`
+</sup>
 
 Call `deprecate` within a function you are deprecating.  It will spit out all the messages to the console the first time _and only the first time_ the method is called.
 
@@ -37,10 +36,9 @@ _program output:_
 **`location`**: a string in the format `${filepath}:${line}:${column}` indicating where the deprecated function was called from.  _TODO: `false` disables outputting the location and will only log the message once._
 
 ### deprecate.method()
-> function signature:
-```js
-deprecate.method(Object proto, String methodName, [String message1 [, String message2 [,...]]], [Object options])
-```
+<sup>
+`deprecate.method(Object proto, String methodName, [String message1 [, String message2 [,...]]], [Object options])`
+</sup>
 
 Deprecates a method on an object:
 
@@ -49,10 +47,9 @@ deprecate.method(console, 'log', 'You should not log.');
 ```
 
 ### deprecate.fn()
-> function signature:
-```js
-deprecate.fn(Function func, [String message1 [, String message2 [,...]]], [Object options])
-```
+<sup>
+`deprecate.fn(Function func, [String message1 [, String message2 [,...]]], [Object options])`
+</sup>
 
 Deprecates a function and returns it:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://secure.travis-ci.org/brianc/node-deprecate.png?branch=master)](http://travis-ci.org/brianc/node-deprecate)
 
-Mark a method as deprecated.  Write a message to a stream once for each location in an application the deprecated method is called.
+Mark a method as deprecated.  Write a message to a stream once for each location in an application the deprecated method is called from.
 
 ## api
 
@@ -83,7 +83,7 @@ When `true`, do nothing when the deprecate method is called.
 
 ### deprecate.stream
 
-The to which output is written.  Defaults to `process.stderr`.
+The stream to which output is written.  Defaults to `process.stderr`.
 
 ### deprecate.log(message)
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,9 @@ Controls the colors used when logging. Default value:
 }
 ```
 
-_How the default looks on a light background:_
+_How the default looks on a dark background vs. a light background:_
 
-<img width="344" src="https://cloud.githubusercontent.com/assets/1958812/20812832/f2a1edb6-b7c7-11e6-81f5-73319ae5f968.png">
-
-_And on a dark background:_
-
-<img width="373" src="https://cloud.githubusercontent.com/assets/1958812/20812831/f2a1cde0-b7c7-11e6-93e6-1613e028e719.png">
+<img width="373" src="https://cloud.githubusercontent.com/assets/1958812/20812831/f2a1cde0-b7c7-11e6-93e6-1613e028e719.png"><img width="344" src="https://cloud.githubusercontent.com/assets/1958812/20812832/f2a1edb6-b7c7-11e6-81f5-73319ae5f968.png">
 
 ### deprecate.silence
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var newline = /(\r\n|\r|\n)/g;
 var slice = [].slice;
 var hits = {};
 
-deprecate = module.exports = isDevelopment ? deprecate : noop;
+deprecate = isDevelopment ? deprecate : noop;
 deprecate.method = isDevelopment ? method : noop;
 deprecate.fn = isDevelopment ? fn : noopReturn;
 deprecate.log = log;
@@ -16,6 +16,12 @@ deprecate.stream = typeof process !== 'undefined' && process.stderr;
 deprecate.silence = false;
 deprecate.color = deprecate.stream && deprecate.stream.isTTY;
 deprecate.colors = { warning:'\x1b[31;1m', message:false, location:'\u001b[90m' };
+
+if(typeof module !== 'undefined' && module.exports) {
+  module.exports = deprecate;
+} else if(typeof window !== 'undefined') {
+  window.deprecate = deprecate;
+}
 
 function deprecate() {
   var options;

--- a/index.js
+++ b/index.js
@@ -83,18 +83,32 @@ function format(message, color) {
 }
 
 function getLocation() {
+    var frame;
     var location = '';
-    var stackIndex = 3;
+    var stackIndexOfDeprecatedFunctionCall = 4;
+
+    /*
+      0: getRawStack - line error is created
+      1: getLocation - line getRawStack() is called
+      2: deprecate - line getLocation() is called
+      3: "the deprecated function" - line deprecate() is called
+      4: "the function that called the deprecated function" - line the deprecated function is called
+    */
 
     try {
-      var frame;
-      var restore = patch(Error, 'prepareStackTrace', returnStack);
-      frame = new Error().stack[stackIndex];
-      restore();
+      frame = getRawStack()[stackIndexOfDeprecatedFunctionCall];
       location = frame.getFileName()+':'+frame.getLineNumber()+':'+frame.getColumnNumber();
     } catch(e) {}
 
     return location;
+}
+
+function getRawStack() {
+  var stack;
+  var restore = patch(Error, 'prepareStackTrace', returnStack);
+  stack = new Error().stack;
+  restore();
+  return stack;
 }
 
 function patch(object, method, replacement) {

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function deprecate() {
     output += linebreak + format(args[i], deprecate.colors.message);
   }
 
-  if(location) {
+  if(options.location !== false && location) {
     output += linebreak + format('  at '+location.replace(cwd, ''), deprecate.colors.location);
   }
 

--- a/index.js
+++ b/index.js
@@ -87,24 +87,26 @@ function getLocation() {
     var stackIndex = 3;
 
     try {
-        // Save original Error.prepareStackTrace
-        var origPrepareStackTrace = Error.prepareStackTrace;
-
-        // Override with function that just returns `stack`
-        Error.prepareStackTrace = function (_, stack) {
-            return stack;
-        };
-
-        // Evaluate `Error.stack`, which calls our new `Error.prepareStackTrace`
-        var frame = new Error().stack[stackIndex];
-
-        // Restore original `Error.prepareStackTrace`
-        Error.prepareStackTrace = origPrepareStackTrace;
-
-        location = frame.getFileName()+':'+frame.getLineNumber()+':'+frame.getColumnNumber();
+      var frame;
+      var restore = patch(Error, 'prepareStackTrace', returnStack);
+      frame = new Error().stack[stackIndex];
+      restore();
+      location = frame.getFileName()+':'+frame.getLineNumber()+':'+frame.getColumnNumber();
     } catch(e) {}
 
     return location;
+}
+
+function patch(object, method, replacement) {
+  var original = object[method];
+  object[method] = replacement;
+  return function restore() {
+    object[method] = original;
+  }
+}
+
+function returnStack(_, stack) {
+  return stack;
 }
 
 function noop(){};

--- a/index.js
+++ b/index.js
@@ -88,11 +88,11 @@ function getLocation() {
     var stackIndexOfDeprecatedFunctionCall = 4;
 
     /*
-      0: getRawStack - line error is created
-      1: getLocation - line getRawStack() is called
-      2: deprecate - line getLocation() is called
-      3: "the deprecated function" - line deprecate() is called
-      4: "the function that called the deprecated function" - line the deprecated function is called
+      0: getRawStack: call to new Error()
+      1: getLocation: call to getRawStack()
+      2: deprecate: call to getLocation()
+      3: "the deprecated function": call to deprecate()
+      4: "the function that called the deprecated function": call to the deprecated function
     */
 
     try {

--- a/index.js
+++ b/index.js
@@ -1,28 +1,106 @@
-var os = require('os');
+var env = typeof process !== 'undefined' && process.env.NODE_ENV;
+var isWindows = typeof process !== 'undefined' && 'win32' === process.platform;
+var isDevelopment = !env || env === 'dev' || env === 'development';
+var logger = typeof console !== 'undefined' && console.warn && console;
+var cwd = typeof process !== 'undefined' && process.cwd() + '/' || '';
+var linebreak = isWindows ? '\r\n' : '\n';
+var newline = /(\r\n|\r|\n)/g;
+var slice = [].slice;
+var noop = function(){};
+var noopReturn = function(r){ return r; };
+var hits = {};
 
-var hits = {
-};
-var deprecate = module.exports = function(methodName, message) {
+var deprecate = module.exports = !isDevelopment ? noop : function() {
+  var options;
+  var location;
+  var args = arguments;
+
+  if(typeof args[args.length-1] === 'object') {
+    options = args[args.length-1];
+    args = slice.call(args, 0, -1);
+  } else {
+    options = {};
+  }
+
+  location = (options.location || getLocation()).replace(cwd, '');
+
   if(deprecate.silence) return;
-  if(hits[deprecate.caller]) return;
-  hits[deprecate.caller] = true;
-  deprecate.stream.write(os.EOL);
-  if(deprecate.color) {
-    deprecate.stream.write(deprecate.color);
+  if(hits[location || deprecate.caller]) return;
+
+  hits[location || deprecate.caller] = true;
+
+  deprecate.log('');
+  deprecate.log('WARNING!!', deprecate.colors.warning);
+
+  for(var i = 0; i < args.length; i++) {
+    deprecate.log(args[i], deprecate.colors.message);
   }
-  deprecate.stream.write('WARNING!!');
-  deprecate.stream.write(os.EOL);
-  for(var i = 0; i < arguments.length; i++) {
-    deprecate.stream.write(arguments[i]);
-    deprecate.stream.write(os.EOL);
+
+  if(location) {
+    deprecate.log('  at '+location, deprecate.colors.location);
   }
-  if(deprecate.color) {
-    deprecate.stream.write('\x1b[0m');
-  }
-  deprecate.stream.write(os.EOL);
-  deprecate.stream.write(os.EOL);
+
+  deprecate.log(linebreak);
 };
 
-deprecate.stream = process.stderr;
+deprecate.method = !isDevelopment ? noop : function(object, methodName) {
+    var originalMethod = object[methodName];
+    var args = slice.call(arguments, 2);
+
+    object[methodName] = function() {
+        deprecate.apply(null, args);
+        return originalMethod.apply(this, arguments);
+    };
+}
+
+deprecate.function = !isDevelopment ? noopReturn : function(fn) {
+  var args = slice.call(arguments, 1);
+
+  return function() {
+    deprecate.apply(null, args);
+    return fn.apply(this, arguments);
+  }
+}
+
+deprecate.log = function(message, color) {
+  var formatted = format(message, color);
+  if(deprecate.stream) {
+    deprecate.stream.write(formatted+linebreak);
+  } else if(logger) {
+    logger.warn(formatted);
+  }
+}
+
+deprecate.stream = typeof process !== 'undefined' && process.stderr;
 deprecate.silence = false;
-deprecate.color = deprecate.stream.isTTY && '\x1b[31;1m';
+deprecate.color = deprecate.stream && deprecate.stream.isTTY;
+deprecate.colors = { warning:'\x1b[31;1m', message:false, location:'\u001b[90m' };
+
+function format(message, color) {
+  return color && deprecate.color ? color + message + '\x1b[0m' : message;
+}
+
+function getLocation() {
+    var location = '';
+    var stackIndex = 3;
+
+    try {
+        // Save original Error.prepareStackTrace
+        var origPrepareStackTrace = Error.prepareStackTrace;
+
+        // Override with function that just returns `stack`
+        Error.prepareStackTrace = function (_, stack) {
+            return stack;
+        };
+
+        // Evaluate `Error.stack`, which calls our new `Error.prepareStackTrace`
+        var frame = new Error().stack[stackIndex];
+
+        // Restore original `Error.prepareStackTrace`
+        Error.prepareStackTrace = origPrepareStackTrace;
+
+        location = frame.getFileName()+':'+frame.getLineNumber()+':'+frame.getColumnNumber();
+    } catch(e) {}
+
+    return location;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -103,7 +103,7 @@ describe('deprecate', function() {
   it('can wrap a function', function() {
     var called;
 
-    var foo = deprecate.function(function foo(a, b, c) {
+    var foo = deprecate.fn(function foo(a, b, c) {
       called = { a:a, b:b, c:c };
     }, 'Don\'t call foo');
 

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,24 @@ describe('deprecate', function() {
     assert(text.indexOf(deprecate.colors.warning) > 0, 'should have color');
   });
 
+  it('allows location to be turned off and then only prints once per call', function() {
+    function foo() {
+      deprecate('foo is deprecated', { location:false });
+    }
+
+    assert.equal(output._text.length, 0);
+
+    // logs the first time
+    foo();
+    var text = output._text.join(' ');
+    var length = output._text.length;
+    assert(text.indexOf('WARNING') > 0, 'should have contained the string "warning"');
+    assert.equal(text.indexOf(' at '), -1, 'should not have the location');
+
+    // but not the second
+    foo();
+    assert.equal(output._text.length, length);
+  })
 
   it('does not print color if color turned off', function() {
     deprecate.color = false;

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,14 @@ var assert = require('assert');
 
 var deprecate = require(__dirname + '/../');
 
+function someDeprecatedMethod() {
+  deprecate('someDeprecatedMethod() is deprecated');
+}
+
+function callsSomeDeprecatedMethod() {
+  someDeprecatedMethod()
+}
+
 var output = {
   _text: [],
   _clear: function() {
@@ -18,6 +26,16 @@ describe('deprecate', function() {
     deprecate.stream = output;
   });
 
+  it('prints the correct location', function() {
+    someDeprecatedMethod();
+    someDeprecatedMethod();
+
+    // IF THIS TEST IS FAILING, CHECK THAT THE LINES MATCH THE TWO CALLS ABOVE!
+    var text = output._text.join(' ');
+    assert(text.indexOf('test/index.js:30:5') > 0, 'should have first location');
+    assert(text.indexOf('test/index.js:31:5') > 0, 'should have second location');
+  });
+
   it('does nothing if silence is turned on', function() {
     deprecate.silence = true;
     deprecate('this method is deprecated and will be removed');
@@ -32,7 +50,7 @@ describe('deprecate', function() {
     assert(text.indexOf('line1') > 0, 'should have contained the string "line1"');
     assert(text.indexOf('line2') > 0, 'should have contained the string "line2"');
     assert(text.indexOf('line2') > text.indexOf('line1'), 'line 2 should come after line 1');
-    assert(text.indexOf(deprecate.color) > 0, 'should have color');
+    assert(text.indexOf(deprecate.colors.warning) > 0, 'should have color');
   });
 
 
@@ -44,21 +62,58 @@ describe('deprecate', function() {
     assert.equal(text.indexOf('\x1b[0m'), -1, 'should not have reset color char ');
   });
 
-  it('only prints once for each function deprecated', function() {
-    var someDeprecatedMethod = function() {
-      deprecate('first');
-    }
-    var someOtherDeprecatedMethod = function() {
-      deprecate('second');
-    }
+  it('only prints once for each call location', function() {
     assert.equal(output._text.length, 0);
-    someDeprecatedMethod();
+
+    // this should output since it is the first time
+    // `callsSomeDeprecatedMethod` will call the deprecated method
+    callsSomeDeprecatedMethod();
     var length = output._text.length;
     assert(length > 0, "should have printed deprecation warning");
-    someDeprecatedMethod();
+
+    // this should NOT output since the deprecated method
+    // has already been called by `callsSomeDeprecatedMethod`
+    callsSomeDeprecatedMethod();
     assert.equal(length, output._text.length, "should not have warned again");
-    someOtherDeprecatedMethod();
+
+    // this should output because it's a new call to the deprecated method
+    someDeprecatedMethod();
     assert(output._text.length > length);
+  });
+
+  it('can wrap a method', function() {
+    var called;
+
+    function Test() {}
+    Test.prototype.foo = function(a, b, c) {
+      called = { a:a, b:b, c:c };
+    };
+    deprecate.method(Test.prototype, 'foo', 'Don\'t call foo');
+
+    var test = new Test();
+    test.foo(1, 2, 3);
+
+    var text = output._text.join(' ');
+    assert(text.indexOf('Don\'t call foo') > 0, 'should have contained message');
+    assert(called.a === 1, 'should have passed the arguments to the function');
+    assert(called.b === 2, 'should have passed the arguments to the function');
+    assert(called.c === 3, 'should have passed the arguments to the function');
+  });
+
+  it('can wrap a function', function() {
+    var called;
+
+    var foo = deprecate.function(function foo(a, b, c) {
+      called = { a:a, b:b, c:c };
+    }, 'Don\'t call foo');
+
+    foo(1, 2, 3);
+
+    var text = output._text.join(' ');
+    assert(text.indexOf('Don\'t call foo') > 0, 'should have contained message');
+    assert(called.a === 1, 'should have passed the arguments to the function');
+    assert(called.b === 2, 'should have passed the arguments to the function');
+    assert(called.c === 3, 'should have passed the arguments to the function');
   });
 
 });


### PR DESCRIPTION
@brianc I figured it would be easier to show you what I meant in #3.

### Helper methods
**`deprecate.method`**:
```js
deprecate.method(console, 'log', 'console.log() is deprecated. no logs for you.');
```
**`deprecate.fn`**:
```js
console.log = deprecate.fn(console.log, 'console.log() is deprecated. no logs for you.');
```

### Location

The location is now pulled from a stack trace and shows a level above where the `deprecate` function was called, that is not the location of the call to `deprecate` but the location of the call to the deprecated function (see example in #3).

#### Custom location
```js
deprecate('message', { location:'test.js:27:4' });
```
For times when you can't get the location from a stack trace (e.g. compile-time deprecations). If the last argument is an object, it will be treated as an options argument and is not logged.

The current behavior of passing an object as an argument would be to get `[Object object]` in the output.  So this is a "**breaking change**", because that would no longer be output.  However the documented signature is `deprecate(string1, [string2, [string3, [...]]]]);`, so users shouldn't be doing that.  

#### One message per location

Instead of one message per `deprecate` call.  This is a "**breaking change**" in that users may find they get more logs in their output than before.  An example:

> A user has an application with 10 pages that use the same deprecated api method.  This user will receive up to 10 deprecation notices in their logs, one for each call to the deprecated method.  This will enable them to, in one go, see all the locations they are using the deprecated method and fix them.  Instead of running, fixing one, running again, fixing another, etc.

#### Disabling location

You can set `options` to `{ location:false }` to disable logging the location and log it once per location of call to deprecate.  With this you get _almost_ the same behavior as previous to this pull request.

### Color changes

`deprecate.color` no longer takes a color string, but rather a `true`/`false` value to indicate whether or not colors should be used.  This a "**breaking change**" in that the user might not get the warning printed in the color they expect.

Instead, `deprecate.colors` is now exposed as an object that contains colors for the `warning` (default: bold, red), `message` (default: false - use system color), `location` (default: gray).

#### Screenshots of the default colors

_On a dark background:_
<img width="373" alt="screen shot 2016-12-01 at 1 12 32 pm" src="https://cloud.githubusercontent.com/assets/1958812/20812831/f2a1cde0-b7c7-11e6-93e6-1613e028e719.png">

_On a light background:_
<img width="344" alt="screen shot 2016-12-01 at 1 12 41 pm" src="https://cloud.githubusercontent.com/assets/1958812/20812832/f2a1edb6-b7c7-11e6-81f5-73319ae5f968.png">

### Browser support 
Allows you to use this in the browser without a module bundler, exposed as `window.deprecate`.